### PR TITLE
[fix] fix for Feature::isUserInPercentage() method

### DIFF
--- a/src/Feature.php
+++ b/src/Feature.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 
+ *
  */
 
 namespace Opensoft\Rollout;
@@ -183,7 +183,7 @@ class Feature
      */
     private function isUserInPercentage(RolloutUserInterface $user)
     {
-        return crc32($user->getRolloutIdentifier()) % 100 < $this->percentage;
+        return abs(crc32($user->getRolloutIdentifier()) % 100) < $this->percentage;
     }
 
     /**
@@ -210,4 +210,4 @@ class Feature
 
         return false;
     }
-} 
+}


### PR DESCRIPTION
The CRC32 % 100 returns negative numbers that are _always_ lower than feature percentage.
