### PR TITLE
Add ZF2 module reference in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ Symfony2 Bundle
 
 A Symfony2 bundle is available to integrate rollout into Symfony2 projects.  It can be found at http://github.com/opensoft/OpensoftRolloutBundle.
 
+Zend Framework 2 Module
+-----------------------
+
+A Zend Framework 2 module is availabile to intergrate rollout into Zend Framwork 2 projects. It can be found at https://github.com/adlogix/zf2-opensoft-rollout.
+
 Implementations in other languages
 ----------------------------------
 


### PR DESCRIPTION
Hello Opensoft team,

First of all thank you for making this php port of the Rollout library. 

As we are going to use that in our project, written in ZF2, we created a zf2 module. It's not completely finished (documentation is missing etc, ...) but it works.

So if you want to reach zend developers too, please accept this PR which adds a reference to our zf module.

Cheers from Adlogix