### PR TITLE
fix multiple user entries during addUser persistance

### DIFF
--- a/src/Feature.php
+++ b/src/Feature.php
@@ -100,7 +100,7 @@ class Feature
      */
     public function addUser(RolloutUserInterface $user)
     {
-        if (!in_array($user, $this->users)) {
+        if (!in_array($user->getRolloutIdentifier(), $this->users)) {
             $this->users[] = $user->getRolloutIdentifier();
         }
     }


### PR DESCRIPTION
The addUser checks if the user object is present in an array of string which
obviously always return false