### PR TITLE
Group eligibility for anonymous users

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ $rollout->activateGroup('chat', 'all');
 You may also want to define your own groups.  We have one for caretakers:
 
 ```php
-$rollout->defineGroup('caretakers', function(RolloutUserInterface $user) {
+$rollout->defineGroup('caretakers', function(RolloutUserInterface $user = null) {
+  if (null === $user) {
+    return false;
+  }
+
   return $user->isCaretaker(); // boolean
 });
 ```

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -189,13 +189,15 @@ class Feature
     public function isActive(Rollout $rollout, RolloutUserInterface $user = null, array $requestParameters = array())
     {
         if (null == $user) {
-            return $this->isParamInRequestParams($requestParameters) || $this->percentage == 100;
+            return $this->isParamInRequestParams($requestParameters)
+                || $this->percentage == 100
+                || $this->isInActiveGroup($rollout);
         }
 
         return $this->isParamInRequestParams($requestParameters) ||
             $this->isUserInPercentage($user) ||
             $this->isUserInActiveUsers($user) ||
-            $this->isUserInActiveGroup($user, $rollout);
+            $this->isInActiveGroup($rollout, $user);
     }
 
     /**
@@ -244,11 +246,11 @@ class Feature
     }
 
     /**
-     * @param RolloutUserInterface $user
      * @param Rollout $rollout
+     * @param RolloutUserInterface|null $user
      * @return bool
      */
-    private function isUserInActiveGroup(RolloutUserInterface $user, Rollout $rollout)
+    private function isInActiveGroup(Rollout $rollout, RolloutUserInterface $user = null)
     {
         foreach ($this->groups as $group) {
             if ($rollout->isActiveInGroup($group, $user)) {

--- a/src/Rollout.php
+++ b/src/Rollout.php
@@ -183,10 +183,10 @@ class Rollout
 
     /**
      * @param string $group
-     * @param RolloutUserInterface $user
+     * @param RolloutUserInterface|null $user
      * @return bool
      */
-    public function isActiveInGroup($group, RolloutUserInterface $user)
+    public function isActiveInGroup($group, RolloutUserInterface $user = null)
     {
         if (!isset($this->groups[$group])) {
             return false;


### PR DESCRIPTION
When user is `null` groups are simply ignored.

Groups could rely on other properties than user's ones.
In my case I need a group (let's say `employees`) that relies on an ENV variable or a client IP.
