### PR TITLE
Fix: Require ext-mongo to run test

### DIFF
--- a/tests/Storage/MongoDBStorageAdapterTest.php
+++ b/tests/Storage/MongoDBStorageAdapterTest.php
@@ -4,6 +4,9 @@ namespace Opensoft\Tests\Storage;
 
 use Opensoft\Rollout\Storage\MongoDBStorageAdapter;
 
+/**
+ * @requires extension mongo
+ */
 class MongoDBStorageAdapterTest extends \PHPUnit_Framework_TestCase
 {
     private $mongo;


### PR DESCRIPTION
This PR

* [x] adds a class-level `@requires` annotation to a test requiring `ext/mongo`

💁‍♂️ For reference, see https://phpunit.readthedocs.io/en/7.1/incomplete-and-skipped-tests.html#skipping-tests-using-requires.

### Before

![screen shot 2018-05-22 at 15 22 28](https://user-images.githubusercontent.com/605483/40365049-09a07c22-5dd4-11e8-9b8a-8fe6485d67e5.png)

### After

![screen shot 2018-05-22 at 15 22 48](https://user-images.githubusercontent.com/605483/40365056-0d09849e-5dd4-11e8-8fcb-318e4236681c.png)

