### PR TITLE
Add feature data

### DIFF
--- a/src/Feature.php
+++ b/src/Feature.php
@@ -36,6 +36,11 @@ class Feature
     private $requestParam;
 
     /**
+     * @var array
+     */
+    private $data = array();
+
+    /**
      * @param string $name
      * @param string|null $settings
      */
@@ -44,9 +49,16 @@ class Feature
         $this->name = $name;
         if ($settings) {
             $settings = explode('|', $settings);
-            if (count($settings) == 4) {
-                $rawRequestParam = array_pop($settings);
+
+            if (isset($settings[3])) {
+                $rawRequestParam = $settings[3];
                 $this->requestParam = $rawRequestParam;
+            }
+
+            //We can not trust the list function because of backwords compatibility
+            if (isset($settings[4])) {
+                $rawData = $settings[4];
+                $this->data = !empty($rawData)? json_decode($rawData, true) : array();
             }
 
             list($rawPercentage, $rawUsers, $rawGroups) = $settings;
@@ -92,6 +104,7 @@ class Feature
             implode(',', $this->users),
             implode(',', $this->groups),
             $this->requestParam,
+            json_encode($this->data)
         ));
     }
 
@@ -168,6 +181,22 @@ class Feature
     }
 
     /**
+     * @return array
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param array $data
+     */
+    public function setData(array $data)
+    {
+        $this->data = $data;
+    }
+
+    /**
      * Clear the feature of all configuration
      */
     public function clear()
@@ -176,6 +205,7 @@ class Feature
         $this->users = array();
         $this->percentage = 0;
         $this->requestParam = '';
+        $this->data = array();
     }
 
     /**
@@ -210,6 +240,7 @@ class Feature
             'groups' => $this->groups,
             'users' => $this->users,
             'requestParam' => $this->requestParam,
+            'data'=> $this->data
         );
     }
 

--- a/src/Rollout.php
+++ b/src/Rollout.php
@@ -233,6 +233,41 @@ class Rollout
     }
 
     /**
+     * Update feature specific data
+     *
+     * @example $rollout->setFeatureData('chat', array(
+     *  'description'  => 'foo',
+     *  'release_date' => 'bar',
+     *  'whatever'     => 'baz'
+     * ));
+     *
+     * @param string $feature
+     * @param array  $data
+     */
+    public function setFeatureData($feature, array $data)
+    {
+        $feature = $this->get($feature);
+        if ($feature) {
+            $feature->setData(array_merge($feature->getData(), $data));
+            $this->save($feature);
+        }
+    }
+
+    /**
+     * Clear all feature data
+     *
+     * @param  string $feature
+     */
+    public function clearFeatureData($feature)
+    {
+        $feature = $this->get($feature);
+        if ($feature) {
+            $feature->setData(array());
+            $this->save($feature);
+        }
+    }
+
+    /**
      * @return array
      */
     public function features()

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -25,4 +25,15 @@ class FeatureTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['fivesonly'], $feature->getGroups());
         $this->assertEquals('FF_facebookIntegration=1', $feature->getRequestParam());
     }
+
+    public function testParseDataSettingsFormat()
+    {
+        $feature = new Feature('chat', '100|4,12|fivesonly|FF_facebookIntegration=1|{"description":"foo","release_date":"bar"}');
+
+        $this->assertEquals(100, $feature->getPercentage());
+        $this->assertEquals([4, 12], $feature->getUsers());
+        $this->assertEquals(['fivesonly'], $feature->getGroups());
+        $this->assertEquals('FF_facebookIntegration=1', $feature->getRequestParam());
+        $this->assertEquals('{"description":"foo","release_date":"bar"}', json_encode($feature->getData()));
+    }
 }

--- a/tests/RolloutTest.php
+++ b/tests/RolloutTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 
+ *
  */
 
 use Opensoft\Rollout\Rollout;
@@ -256,6 +256,11 @@ class RolloutTest extends \PHPUnit_Framework_TestCase
         $this->rollout->activate('signup');
         $this->rollout->activateUser('chat', new RolloutUser(42));
         $this->rollout->activateRequestParam('chat', 'FF_facebookIntegration=1');
+        $this->rollout->setFeatureData('chat', array(
+            'description'  => 'foo',
+            'release_date' => 'bar',
+            'whatever'     => 'baz'
+        ));
 
         // it should return the feature object
         $feature = $this->rollout->get('chat');
@@ -268,7 +273,12 @@ class RolloutTest extends \PHPUnit_Framework_TestCase
                 'groups' => array('caretakers', 'greeters'),
                 'percentage' => 10,
                 'users' => array('42'),
-                'requestParam' => 'FF_facebookIntegration=1'
+                'requestParam' => 'FF_facebookIntegration=1',
+                'data' => array(
+                    'description'  => 'foo',
+                    'release_date' => 'bar',
+                    'whatever'     => 'baz'
+                )
             ),
             $feature->toArray()
         );
@@ -278,6 +288,7 @@ class RolloutTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($feature->getUsers());
         $this->assertEquals(100, $feature->getPercentage());
         $this->assertEmpty($feature->getRequestParam());
+        $this->assertEmpty($feature->getData());
     }
 
     public function testRemove()
@@ -288,6 +299,33 @@ class RolloutTest extends \PHPUnit_Framework_TestCase
 
         $this->rollout->remove('signup');
         $this->assertNotContains('signup', $this->rollout->features());
+    }
+
+    public function testClearFeatureData()
+    {
+        $this->rollout->activate('signup');
+        $feature = $this->rollout->get('signup');
+        $this->assertEquals('signup', $feature->getName());
+
+        $this->rollout->setFeatureData('signup', array(
+            'description'  => 'foo',
+            'release_date' => 'bar',
+            'whatever'     => 'baz'
+        ));
+
+        $feature = $this->rollout->get('signup');
+
+        $this->assertEquals(array(
+            'description'  => 'foo',
+            'release_date' => 'bar',
+            'whatever'     => 'baz'
+        ), $feature->getData());
+
+        $this->rollout->clearFeatureData('signup');
+
+        $feature = $this->rollout->get('signup');
+
+        $this->assertEmpty($feature->getData());
     }
 }
 


### PR DESCRIPTION
In the original Ruby variant you can set Feature data:

`$rollout.set_feature_data(:chat, description: 'foo', release_date: 'bar', whatever: 'baz')`.

I added the method and of course also the `clearFeatureData` method.