### PR TITLE
Fix creation of 'all' group to allow null user to be passed

### DIFF
--- a/src/Rollout.php
+++ b/src/Rollout.php
@@ -29,7 +29,7 @@ class Rollout
     {
         $this->storage = $storage;
         $this->groups = array(
-            'all' => function(RolloutUserInterface $user) { return $user !== null; }
+            'all' => function(?RolloutUserInterface $user) { return $user !== null; }
         );
     }
 


### PR DESCRIPTION
If you check for a feature being active with no user passed in, the underlying test for `::isActiveInGroup` fails as the closure method signature doesn't allow a null to be passed.